### PR TITLE
Browse likes

### DIFF
--- a/memory_trunk/memory_trunk_app/templates/index.html
+++ b/memory_trunk/memory_trunk_app/templates/index.html
@@ -48,6 +48,16 @@
                 </li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="http://example.com" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        Likes <span class="glyphicon glyphicon-menu-down"></span>
+                    </a>
+                    <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                        <a class="dropdown-item" href="/liked_memories/{{request.user.id}}">Memories</a>
+                        <a class="dropdown-item" href="/liked_tips/{{request.user.id}}">Tips</a>
+                        <a class="dropdown-item" href="/liked_perspectives/{{request.user.id}}">Perspectives</a>
+                    </div>
+                </li>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="http://example.com" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         Community Trunk <span class="glyphicon glyphicon-menu-down"></span>
                     </a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">

--- a/memory_trunk/memory_trunk_app/urls.py
+++ b/memory_trunk/memory_trunk_app/urls.py
@@ -21,7 +21,7 @@ urlpatterns = [
     url(r'^login', views.login_views.LoginUserView.as_view(), name='login_user_view'),
 
 
-    # CREATION FORM VIEWS
+    # CREATION FORMS
     
         # Memory
     url(r'^hippocampus', views.hippocampus_view, name='hippocampus'),
@@ -38,17 +38,17 @@ urlpatterns = [
         # Memory
     url(r'^memory_list/(?P<id>\d+)/$', login_required(views.MemoryListView.as_view()), name='memory_list'),
     url(r'^community_memories/', views.PublicMemoryListView.as_view(), name='public_memory_list'),
-    url(r'^liked_memories/(?P<id>\d+)/$', views.LikedMemoriesListView.as_view(), name='liked_memories'),
+    url(r'^liked_memories/(?P<id>\d+)/$', views.LikedMemoriesView.as_view(), name='liked_memories'),
 
         # Tip
     url(r'^tip_list/(?P<id>\d+)/$', login_required(views.TipListView.as_view()), name='tip_list'),
     url(r'^community_tips/', views.PublicTipListView.as_view(), name='public_tip_list'),
-    url(r'^liked_tips/(?P<id>\d+)/$', views.LikedTipsListView.as_view(), name='liked_tips'),
+    url(r'^liked_tips/(?P<id>\d+)/$', views.LikedTipsView.as_view(), name='liked_tips'),
 
         # Perspective
     url(r'^perspective_list/(?P<id>\d+)/$', login_required(views.PerspectiveListView.as_view()), name='perspective_list'),
     url(r'^community_perspectives/', views.PublicPerspectiveListView.as_view(), name='public_perspective_list'),
-    url(r'^liked_perspectives/(?P<id>\d+)/$', views.LikedPerspectivesListView.as_view(), name='liked_perspectives'),
+    url(r'^liked_perspectives/(?P<id>\d+)/$', views.LikedPerspectivesView.as_view(), name='liked_perspectives'),
 
 
     # DETAIL VIEWS
@@ -75,7 +75,7 @@ urlpatterns = [
     url(r'^delete_perspective/(?P<id>\d+)/$', views.delete_perspective, name='delete_perspective'),
 
 
-    # UPDATE VIEWS
+    # OBJECT UPDATE VIEWS
 
         # Memory
     url(r'^update_memory/(?P<id>\d+)/$', views.update_memory, name='update_memory'),

--- a/memory_trunk/memory_trunk_app/urls.py
+++ b/memory_trunk/memory_trunk_app/urls.py
@@ -38,14 +38,17 @@ urlpatterns = [
         # Memory
     url(r'^memory_list/(?P<id>\d+)/$', login_required(views.MemoryListView.as_view()), name='memory_list'),
     url(r'^community_memories/', views.PublicMemoryListView.as_view(), name='public_memory_list'),
+    url(r'^liked_memories/(?P<id>\d+)/$', views.LikedMemoriesListView.as_view(), name='liked_memories'),
 
         # Tip
     url(r'^tip_list/(?P<id>\d+)/$', login_required(views.TipListView.as_view()), name='tip_list'),
     url(r'^community_tips/', views.PublicTipListView.as_view(), name='public_tip_list'),
+    url(r'^liked_tips/(?P<id>\d+)/$', views.LikedTipsListView.as_view(), name='liked_tips'),
 
         # Perspective
     url(r'^perspective_list/(?P<id>\d+)/$', login_required(views.PerspectiveListView.as_view()), name='perspective_list'),
     url(r'^community_perspectives/', views.PublicPerspectiveListView.as_view(), name='public_perspective_list'),
+    url(r'^liked_perspectives/(?P<id>\d+)/$', views.LikedPerspectivesListView.as_view(), name='liked_perspectives'),
 
 
     # DETAIL VIEWS

--- a/memory_trunk/memory_trunk_app/views/__init__.py
+++ b/memory_trunk/memory_trunk_app/views/__init__.py
@@ -12,6 +12,7 @@ from .memory_list_view import MemoryListView, PublicMemoryListView
 from .memory_detail_view import MemoryDetailView, dislike_memory, like_memory
 from .delete_memory_view import delete_memory
 from .update_memory_view import update_memory
+from liked_memory_view import LikedMemoryView
 
 # Tip views
 from .tip_creation_view import tip_creation_view
@@ -19,6 +20,7 @@ from .tip_list_view import TipListView, PublicTipListView
 from .tip_detail_view import TipDetailView, like_tip, dislike_tip
 from .delete_tip_view import delete_tip
 from .update_tip_view import update_tip
+from liked_tips_view import LikedTipsView
 
 # Perspective views
 from .perspective_creation_view import perspective_creation_view
@@ -26,3 +28,4 @@ from .perspective_list_view import PerspectiveListView, PublicPerspectiveListVie
 from .perspective_detail_view import PerspectiveDetailView, like_perspective, dislike_perspective
 from .delete_perspective_view import delete_perspective
 from .update_perspective_view import update_perspective
+from liked_perspectives_view import LikedPerspectivesView

--- a/memory_trunk/memory_trunk_app/views/__init__.py
+++ b/memory_trunk/memory_trunk_app/views/__init__.py
@@ -12,7 +12,7 @@ from .memory_list_view import MemoryListView, PublicMemoryListView
 from .memory_detail_view import MemoryDetailView, dislike_memory, like_memory
 from .delete_memory_view import delete_memory
 from .update_memory_view import update_memory
-from liked_memory_view import LikedMemoryView
+from .liked_memories_view import LikedMemoriesView
 
 # Tip views
 from .tip_creation_view import tip_creation_view
@@ -20,7 +20,7 @@ from .tip_list_view import TipListView, PublicTipListView
 from .tip_detail_view import TipDetailView, like_tip, dislike_tip
 from .delete_tip_view import delete_tip
 from .update_tip_view import update_tip
-from liked_tips_view import LikedTipsView
+from .liked_tips_view import LikedTipsView
 
 # Perspective views
 from .perspective_creation_view import perspective_creation_view
@@ -28,4 +28,4 @@ from .perspective_list_view import PerspectiveListView, PublicPerspectiveListVie
 from .perspective_detail_view import PerspectiveDetailView, like_perspective, dislike_perspective
 from .delete_perspective_view import delete_perspective
 from .update_perspective_view import update_perspective
-from liked_perspectives_view import LikedPerspectivesView
+from .liked_perspectives_view import LikedPerspectivesView

--- a/memory_trunk/memory_trunk_app/views/liked_memories_view.py
+++ b/memory_trunk/memory_trunk_app/views/liked_memories_view.py
@@ -1,0 +1,24 @@
+from django.views.generic.base import TemplateView
+from django.shortcuts import render
+from django.contrib.auth.models import User
+from memory_trunk_app import models
+
+class LikedMemoriesView(TemplateView):
+    """
+    Purpose: 
+        List all of the Memories a user has liked as hyperlinked titles
+    
+    Author: Sam Phillips <samcphillips.com>
+    """
+    template_name = 'memory_list.html'
+
+    def get(self, request, id):
+        perspectives = models.Perspective.objects.filter(user=id)
+        return render(
+            request, 
+            self.template_name, 
+            {
+                'perspectives': perspectives,
+                'page_title': 'My Perspectives'
+            }
+        )

--- a/memory_trunk/memory_trunk_app/views/liked_memories_view.py
+++ b/memory_trunk/memory_trunk_app/views/liked_memories_view.py
@@ -13,12 +13,12 @@ class LikedMemoriesView(TemplateView):
     template_name = 'memory_list.html'
 
     def get(self, request, id):
-        perspectives = models.Perspective.objects.filter(user=id)
+        memories = request.user.memory_likes.all()
         return render(
             request, 
             self.template_name, 
             {
-                'perspectives': perspectives,
-                'page_title': 'My Perspectives'
+                'memories': memories,
+                'page_title': 'Liked Memories'
             }
         )

--- a/memory_trunk/memory_trunk_app/views/liked_perspectives_view.py
+++ b/memory_trunk/memory_trunk_app/views/liked_perspectives_view.py
@@ -13,12 +13,12 @@ class LikedPerspectivesView(TemplateView):
     template_name = 'perspective_list.html'
 
     def get(self, request, id):
-        perspectives = models.Perspective.objects.filter(user=id)
+        perspectives = request.user.perspective_likes.all()
         return render(
             request, 
             self.template_name, 
             {
                 'perspectives': perspectives,
-                'page_title': 'My Perspectives'
+                'page_title': 'Liked Perspectives'
             }
         )

--- a/memory_trunk/memory_trunk_app/views/liked_perspectives_view.py
+++ b/memory_trunk/memory_trunk_app/views/liked_perspectives_view.py
@@ -1,0 +1,24 @@
+from django.views.generic.base import TemplateView
+from django.shortcuts import render
+from django.contrib.auth.models import User
+from memory_trunk_app import models
+
+class LikedPerspectivesView(TemplateView):
+    """
+    Purpose: 
+        List all of the Perspectives a user has liked as hyperlinked titles
+    
+    Author: Sam Phillips <samcphillips.com>
+    """
+    template_name = 'perspective_list.html'
+
+    def get(self, request, id):
+        perspectives = models.Perspective.objects.filter(user=id)
+        return render(
+            request, 
+            self.template_name, 
+            {
+                'perspectives': perspectives,
+                'page_title': 'My Perspectives'
+            }
+        )

--- a/memory_trunk/memory_trunk_app/views/liked_tips_view.py
+++ b/memory_trunk/memory_trunk_app/views/liked_tips_view.py
@@ -13,7 +13,7 @@ class LikedTipsView(TemplateView):
     template_name = 'tip_list.html'
 
     def get(self, request, id):
-        tips = request.user.memory_likes_set.all()
+        tips = request.user.tip_likes.all()
         return render(
             request, 
             self.template_name, 

--- a/memory_trunk/memory_trunk_app/views/liked_tips_view.py
+++ b/memory_trunk/memory_trunk_app/views/liked_tips_view.py
@@ -1,0 +1,24 @@
+from django.views.generic.base import TemplateView
+from django.shortcuts import render
+from django.contrib.auth.models import User
+from memory_trunk_app import models
+
+class LikedTipsView(TemplateView):
+    """
+    Purpose: 
+        List all of the Tips a user has liked as hyperlinked titles
+    
+    Author: Sam Phillips <samcphillips.com>
+    """
+    template_name = 'tip_list.html'
+
+    def get(self, request, id):
+        tips = request.user.memory_likes_set.all()
+        return render(
+            request, 
+            self.template_name, 
+            {
+                'tips': tips,
+                'page_title': 'Liked Tips'
+            }
+        )


### PR DESCRIPTION
## Description
This creates the views to allow users to browse through Memories, Perspectives, and Tips that they have liked


## Related Ticket(s)
fixes #39 

## Expected Behavior
If a user has used the "Like" button visible on a Memory, Tip, or Perspective object's detail view, then that user may now find the object view at a later time by browsing through the "Likes" tab list views for each of these models.


## Steps to Test Solution
Like a few objects, and confirm that they now appear under that user's "Likes" tab.


## Unit Testing
- [ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
- [X] I certify that all existing tests pass

## Documentation

- [X] There is new documentation in this pull request that must be reviewed..
- [X] I added documentation for any new classes/methods

## Deploy Notes
N/A